### PR TITLE
Fix logger timer bug

### DIFF
--- a/pypythia/main.py
+++ b/pypythia/main.py
@@ -158,7 +158,7 @@ def main():
 
     if hours > 0:
         logger.info(
-            f"Total runtime: {int(hours):02d}:{int(minutes):02d}:{seconds:02d} hours ({round(total_runtime)} seconds)."
+            f"Total runtime: {int(hours):02d}:{int(minutes):02d}:{int(seconds):02d} hours ({round(total_runtime)} seconds)."
         )
     elif minutes > 0:
         logger.info(


### PR DESCRIPTION
Fix a bug of the logger timer causing this error for runs of more than an hour: 
```
Traceback (most recent call last):
  File "/home/fdecarpentier/Documents/FrankenPhylo/FufaStein/.snakemake/conda/7ddc770da26d7b8f4436aadb4e950c55_/bin/pythia", line 10, in <module>
    sys.exit(main())
             ~~~~^^
  File "/home/fdecarpentier/Documents/FrankenPhylo/FufaStein/.snakemake/conda/7ddc770da26d7b8f4436aadb4e950c55_/lib/python3.13/site-packages/pypythia/main.py", line 161, in main
    f"Total runtime: {int(hours):02d}:{int(minutes):02d}:{seconds:02d} hours ({round(total_runtime)} seconds)."
                                                         ^^^^^^^^^^^^^
ValueError: Unknown format code 'd' for object of type 'float'
```
I'm no python programmer, but I believed it fixes the issue, I tested it on two large MSAs.